### PR TITLE
Add Support for New Teams

### DIFF
--- a/TeamsLogStatus.ahk
+++ b/TeamsLogStatus.ahk
@@ -5,21 +5,36 @@ SetWorkingDir %A_ScriptDir% ; Ensures a consistent starting directory.
 #SingleInstance force
 #Persistent
 
+; Mode switch: "classic" or "new"
+Mode := "classic"
 
 ; Set the Webhook URI to POST to
 WebhookURI = <ADD YOUR WEBHOOK URI HERE e.g. https://your-home-assistant:8123/api/webhook/some_hook_id>
 
-;Set a default Status
+; Set log paths
+ClassicLogPath = %A_AppData%\Microsoft\Teams\logs.txt
+NewLogPath = %A_AppData%\Local\Packages\MSTeams_8wekyb3d8bbwe\LocalCache\Microsoft\MSTeams\EBWebView\WV2Profile_tfw\Service Worker\CacheStorage\......
+
+; Set a default Status
 CurrentStatus = Unknown
+
+; Set a default prevStatus
+global prevStatus := ""
 
 ; Send a heartbeat webhook anyway every 5 mins
 SetTimer, SendWebhook, 300000
 
-logPath = %A_AppData%\Microsoft\Teams\logs.txt
-lt := new CLogTailer(logPath, Func("NewLine"))
+if (Mode = "classic") {
+    lt := new CLogTailer(ClassicLogPath, Func("NewLine"))
+} else if (Mode = "new") {
+    SetTimer, CheckFile, 1000  ; Check every 1000 milliseconds (1 second)
+}
+
 return
 
-
+; ----------------------
+; Classic mode functions
+; ----------------------
 NewLine(text)
 {
 global CurrentStatus
@@ -59,11 +74,31 @@ class CLogTailer {
 }
 
 ; ----------------------
+; New mode functions
+; ----------------------
+ReadAvailability(NewLogPath) {
+    FileRead, fileContent, %NewLogPath%
+    pattern := """availability"":""([^""]+)"""  ; Ensure this regex pattern is correct
+    if (RegExMatch(fileContent, pattern, found)) {
+        return found1
+    } else {
+        return "Error: Pattern not found"
+    }
+}
+
+CheckFile:
+    currentStatus := ReadAvailability(NewLogPath)
+    if (currentStatus != prevStatus && currentStatus != "Error: Pattern not found") {
+        prevStatus := currentStatus
+        SendWebhook()
+    }
+return
+
+; ----------------------
 ; Function to POST a JSON payload to the Webhook URI defined
 ; ----------------------
 SendWebhook()
 {
-
   global
 	try {
 	WinHTTP := ComObjCreate("WinHTTP.WinHttpRequest.5.1")


### PR DESCRIPTION
#### A new `mode` feature supports both `New` Teams and `Classic` Teams. This update is designed to enhance flexibility and user experience by accommodating different versions of Teams.

### Key Features:

- New Teams Support: Users can now opt for the 'New Teams' mode by setting the `Mode` variable to `"new"`. Additionally, it is required to specify the log file path by updating the `NewLogPath` variable. This mode is tailored to work with the latest Teams interface and features.  The `NewLogPath` variable must be set manually as the new log path is specific to your user and Azure Tenant; it can be easily found by browsing your local machine's directory. 
- Classic Teams Compatibility: The existing functionality for Classic Teams remains intact. Users who prefer the traditional setup need not make any changes as the default `mode` is `"classic"`, ensuring seamless continuity.

### How to Implement:

- For New Teams: Set `Mode := "new"` and ensure `NewLogPath` is correctly specified in the script.
- For Classic Teams: No changes are required. The script will function as before.


#### Finding the new log path:
To locate your log file path, navigate to the following directory:

```\AppData\Local\Packages\MSTeams_8wekyb3d8bbwe\LocalCache\Microsoft\MSTeams\EBWebView\WV2Profile_tfw\Service Worker\CacheStorage\```

In this directory, identify the file that updates when your Microsoft Teams status changes. The complete path to this file typically resembles:

```C:\Users\USERNAME\AppData\Local\Packages\MSTeams_8wekyb3d8bbwe\LocalCache\Microsoft\MSTeams\EBWebView\WV2Profile_tfw\Service Worker\CacheStorage\3abc345ab43a5bd34abab23\ba1561561-3d88-9999-9cc8-5445156c0111```